### PR TITLE
chore!: Upgrade rmcp to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,10 +139,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -562,7 +566,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1130,7 +1134,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1180,12 +1184,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "chrono",
  "futures",
  "pastey",
@@ -1198,13 +1202,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.17.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ ignored = ["chrono", "uuid", "schemars"]
 
 [dependencies]
 zenmoney-rs = { version = "0.4.0", default-features = false, features = ["async", "storage-file"] }
-rmcp = { version = "0.17.0", features = ["server", "transport-io"] }
+rmcp = { version = "3.1.0", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -13,13 +13,7 @@ unmaintained = "all"
 unsound = "workspace"
 # Deny yanked crate versions
 yanked = "deny"
-ignore = [
-    # rmcp < 1.4.0 Host-header/DNS-rebinding issue affects only the
-    # streamable HTTP server transport; this server uses stdio transport
-    # exclusively (features: server, transport-io). Remove once rmcp is
-    # upgraded to >= 1.4.0.
-    "RUSTSEC-2026-0189",
-]
+ignore = []
 
 # -- Licenses --
 [licenses]

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 use zenmoney_rs::models::{
     AccountId, InstrumentId, MerchantId, NaiveDate, SuggestRequest, Tag, TagId, Transaction,
@@ -95,7 +95,7 @@ fn to_json_text<T: serde::Serialize>(value: &T) -> Result<String, McpError> {
 /// Creates a successful tool result containing JSON text.
 fn json_result<T: serde::Serialize>(value: &T) -> Result<CallToolResult, McpError> {
     let text = to_json_text(value)?;
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }
 
 /// Formats an [`AccountType`](zenmoney_rs::models::AccountType) variant as a human-readable string.
@@ -540,7 +540,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
     )]
     async fn sync(&self) -> Result<CallToolResult, McpError> {
         let _response = self.client.sync().await.map_err(zen_err)?;
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             "Sync completed successfully",
         )]))
     }
@@ -551,7 +551,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
     )]
     async fn full_sync(&self) -> Result<CallToolResult, McpError> {
         let _response = self.client.full_sync().await.map_err(zen_err)?;
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             "Full sync completed successfully",
         )]))
     }
@@ -750,7 +750,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
             let result = AccountResponse::from_account(acc, &maps);
             json_result(&result)
         } else {
-            Ok(CallToolResult::success(vec![Content::text(format!(
+            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "No account found with title '{}'",
                 params.0.title
             ))]))
@@ -773,7 +773,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
             let result = TagResponse::from_tag(found_tag, &maps);
             json_result(&result)
         } else {
-            Ok(CallToolResult::success(vec![Content::text(format!(
+            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "No tag found with title '{}'",
                 params.0.title
             ))]))
@@ -813,7 +813,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
             let result = InstrumentResponse::from_instrument(instr);
             json_result(&result)
         } else {
-            Ok(CallToolResult::success(vec![Content::text(format!(
+            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "No instrument found with ID {}",
                 params.0.id
             ))]))
@@ -924,7 +924,7 @@ impl<S: Storage + 'static> ZenMoneyMcpServer<S> {
             );
             json_result(&result)
         } else {
-            Ok(CallToolResult::success(vec![Content::text(format!(
+            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                 "Transaction '{}' deleted successfully (details not available locally)",
                 params.0.id
             ))]))
@@ -2541,15 +2541,14 @@ mod tests {
 #[tool_handler]
 impl<S: Storage + 'static> ServerHandler for ZenMoneyMcpServer<S> {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "ZenMoney personal finance MCP server. \
-                 Use sync/full_sync to fetch data, then query accounts, \
-                 transactions, tags, budgets, and more."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+        let mut info = ServerInfo::default();
+        info.instructions = Some(
+            "ZenMoney personal finance MCP server. \
+             Use sync/full_sync to fetch data, then query accounts, \
+             transactions, tags, budgets, and more."
+                .into(),
+        );
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
     }
 }


### PR DESCRIPTION
## Summary
Stacked on #11. Answers "why not update rmcp" — measured the migration and it turned out to be only two mechanical changes, so doing it now instead of deferring:
- `Content` → `ContentBlock` (renamed in rmcp 3.x)
- `ServerInfo` became non-exhaustive → construct via `Default` + field assignment
- Removes the `deny.toml` ignore for RUSTSEC-2026-0189 added in #11 — the advisory is fixed properly by the upgrade

Fixes #12

## Test plan
- [x] 119 tests pass against rmcp 3.1.0
- [x] clippy/fmt/deny (advisories now clean without ignores)/machete

🤖 Generated with [Claude Code](https://claude.com/claude-code)