### PR TITLE
ci: Build and attach prebuilt binaries on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish
 on:
   push:
     tags: ["v*"]
+  # Manual runs build the binaries only (no crates.io publish, no
+  # GitHub release) — for validating the build matrix.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,6 +17,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
+    if: github.event_name == 'push'
     needs: ci
     runs-on: ubuntu-latest
     environment: crates-io
@@ -24,3 +28,87 @@ jobs:
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    needs: ci
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          name="zenmoney-mcp-${{ matrix.target }}-${GITHUB_REF_NAME}"
+          release_dir="target/${{ matrix.target }}/release"
+          mkdir dist
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            archive="${name}.zip"
+            (cd "$release_dir" && 7z a "../../../dist/${archive}" zenmoney-mcp.exe)
+          else
+            archive="${name}.tar.gz"
+            tar -C "$release_dir" -czf "dist/${archive}" zenmoney-mcp
+          fi
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$archive" > "${archive}.sha256"
+          else
+            shasum -a 256 "$archive" > "${archive}.sha256"
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zenmoney-mcp-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub release
+    if: github.event_name == 'push'
+    needs: [build-binaries, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Extract changelog notes
+        run: |
+          awk -v ver="${GITHUB_REF_NAME#v}" '
+            /^## \[/ { p = index($0, "[" ver "]") > 0 }
+            p
+          ' CHANGELOG.md > notes.md
+          if ! [ -s notes.md ]; then
+            echo "Release ${GITHUB_REF_NAME}" > notes.md
+          fi
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            --verify-tag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,3 +141,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", default-features = false }
 uuid = { version = "1", features = ["v4"] }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,29 @@ Exposes tools (sync, read, search, write, bulk) via the [Model Context Protocol]
 
 ## Installation
 
+### Prebuilt binaries
+
+Download the archive for your platform from the
+[latest release](https://github.com/sakost/zenmoney-mcp/releases/latest),
+verify it against the accompanying `.sha256` file, and unpack the
+`zenmoney-mcp` binary somewhere on your `PATH`.
+
+| Platform | Archive |
+| --- | --- |
+| Linux x86_64 | `zenmoney-mcp-x86_64-unknown-linux-gnu-<tag>.tar.gz` |
+| Linux ARM64 | `zenmoney-mcp-aarch64-unknown-linux-gnu-<tag>.tar.gz` |
+| macOS Intel | `zenmoney-mcp-x86_64-apple-darwin-<tag>.tar.gz` |
+| macOS Apple Silicon | `zenmoney-mcp-aarch64-apple-darwin-<tag>.tar.gz` |
+| Windows x86_64 | `zenmoney-mcp-x86_64-pc-windows-msvc-<tag>.zip` |
+
+With [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall zenmoney-mcp
+```
+
+### From source
+
 ```bash
 cargo install zenmoney-mcp
 ```


### PR DESCRIPTION
## Summary
- Extends the tag-triggered Publish workflow with a 5-target build matrix, each target on its **native** GitHub runner — no cross-compilation: Linux x86_64 (`ubuntu-latest`), Linux aarch64 (`ubuntu-24.04-arm`), macOS Intel (`macos-15-intel`), macOS Apple Silicon (`macos-latest`), Windows x86_64 (`windows-latest`)
- Archives (`.tar.gz`, `.zip` on Windows) + `.sha256` checksums, named per the cargo-binstall convention; `[package.metadata.binstall]` added so `cargo binstall zenmoney-mcp` works from the next crates.io release
- `release` job auto-creates the GitHub Release, notes extracted from the tag's CHANGELOG.md section, all 10 files attached
- `workflow_dispatch` trigger runs the build matrix alone (no publish/release) to validate builds without tagging
- README installation section: per-platform download table, binstall, source fallback

Fixes #5

## Test plan
- [x] actionlint clean (caught the retired `macos-13` runner label → `macos-15-intel`)
- [x] Packaging script executed locally against a real release build: archive layout, naming, sha256 verified
- [x] Changelog-extraction awk tested against the real CHANGELOG.md 0.4.0 section
- [ ] After merge: `workflow_dispatch` run to validate all 5 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)