### PR TITLE
chore: Bump zenmoney-rs to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "zenmoney-rs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fe240518abd9a8da94d079bffb7a872df2b5f576fcdf69ab88d2d47ce131e0"
+checksum = "e9fbaa56021c36deb293e4f2bb89ff4e20dffa55daa8434b380964acb0794aaa"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ wildcard_dependencies = "deny"
 ignored = ["chrono", "uuid", "schemars"]
 
 [dependencies]
-zenmoney-rs = { version = "0.4.0", default-features = false, features = ["async", "storage-file"] }
+zenmoney-rs = { version = "0.4.1", default-features = false, features = ["async", "storage-file"] }
 rmcp = { version = "3.1.0", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/response.rs
+++ b/src/response.rs
@@ -688,7 +688,7 @@ mod tests {
         let merchant = Merchant {
             id: MerchantId::new("m-1".to_owned()),
             changed: DateTime::from_timestamp(1_700_000_000, 0).expect("valid timestamp"),
-            user: UserId::new(1),
+            user: Some(UserId::new(1)),
             title: "Coffee Shop".to_owned(),
         };
         let resp = super::MerchantResponse::from_merchant(&merchant);

--- a/src/server.rs
+++ b/src/server.rs
@@ -2063,7 +2063,7 @@ mod tests {
         let merchants = vec![Merchant {
             id: MerchantId::new("m-1".to_owned()),
             changed: test_timestamp(),
-            user: UserId::new(1),
+            user: Some(UserId::new(1)),
             title: "Coffee Shop".to_owned(),
         }];
         let budgets = vec![Budget {


### PR DESCRIPTION
## Summary
- `zenmoney-rs` 0.4.0 → 0.4.1: `Merchant.user` is now `Option<UserId>` — system merchants (created by ZenMoney itself) return `"user": null`, which crashed the initial sync. This was the root cause of #7, found and fixed by @samosvat via the field-path errors introduced in 0.4.0 (sakost/zenmoney-rs#4).
- Two test fixtures updated for the optional field; production code never reads `merchant.user`.

## Test plan
- [x] 119 tests pass against zenmoney-rs 0.4.1
- [x] clippy/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)